### PR TITLE
Update requirements.txt to mlconjug3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 googletrans
 infi.systray
 keyboard
-mlconjug
+mlconjug3
 psutil
 pygame
 pygetwindow


### PR DESCRIPTION
Hi @JeanExtreme002.

I am the author of mlconjug and I wanted to let you know that mlconjug is now mlconjug3 as I wanted to make explicit that mlconjug3 no longer supports python 2.x as it has been deprecated.

I made this pull request to update your dependency to mlconjug3 as there has been enhancements such as better accuracy in conjugating unknown verbs and many bug fixes.

Cheers,

SekouDiaoNLP.